### PR TITLE
Low lift hover effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ An image at the top, content at the bottom, and an optional `...` button which c
 - `custom-image-format`: Add this attribute if you want to provide something in the `tile-image` slot rather than using the `img-url`
 - `show-menu`: Add this attribute if you want the `...` dropdown menu to appear
 - `dropdown-aria-label`: A string which will be provided to the aria-label
+- `hover-effect`: A string containing space separated hover effects you would like to apply to the tile
+	- `low-lift`: A hover effect where the tile lifts slightly off the page
 
 ### CSS Variables:
 - `--tile-image-height`: The height you want the image to be

--- a/d2l-tile.html
+++ b/d2l-tile.html
@@ -106,7 +106,8 @@
 				transition: transform 0.2s, box-shadow 0.2s;
 			}
 
-			:host([hover-effect~="low-lift"]:hover) {
+			:host([hover-effect~="low-lift"]:hover),
+			:host([hover-effect~="low-lift"]:focus) {
 				transform: scale(1.03);
 				box-shadow: 0 4px 10px 0 var(--d2l-color-titanius);
 			}

--- a/d2l-tile.html
+++ b/d2l-tile.html
@@ -8,7 +8,7 @@
 	<template>
 		<style>
 			:host([show-menu]) {
-				overflow: auto;
+				overflow: visible;
 			}
 
 			:host {

--- a/d2l-tile.html
+++ b/d2l-tile.html
@@ -7,6 +7,10 @@
 <dom-module id="d2l-tile">
 	<template>
 		<style>
+			:host([show-menu]) {
+				overflow: auto;
+			}
+
 			:host {
 				width: 350px;
 				border: 1px var(--d2l-color-titanius) solid;
@@ -18,6 +22,7 @@
 				position: relative;
 				font: inherit;
 				background: white;
+				overflow: hidden;
 			}
 
 			:host:hover d2l-dropdown > button,
@@ -96,6 +101,15 @@
 				z-index: 2;
 				position: relative;
 			}
+
+			:host([hover-effect~="low-lift"]) {
+				transition: transform 0.2s, box-shadow 0.2s;
+			}
+
+			:host([hover-effect~="low-lift"]:hover) {
+				transform: scale(1.03);
+				box-shadow: 0 4px 10px 0 var(--d2l-color-titanius);
+			}
 		</style>
 		<div class="d2l-tile-image-container">
 			<template is="dom-if" if="[[customImageFormat]]">
@@ -133,8 +147,17 @@
 		properties: {
 			dropdownAriaLabel: String,
 			imgUrl: String,
-			showMenu: Boolean,
-			customImageFormat: Boolean
+			showMenu: {
+				type: Boolean,
+				value: false,
+				reflectToAttribute: true
+			},
+			customImageFormat: Boolean,
+			hoverEffect: {
+				type: String,
+				value: '',
+				reflectToAttribute: true
+			}
 		},
 		hostAttributes: {
 			tabindex: 0


### PR DESCRIPTION
Together, this group of PRs adds hover effects to User-tile, Evidence-tile, and fixes a bug where tabbing through the evidence tiles in PP would highlight their d2l-menus

https://rally1.rallydev.com/#/95185052972d/detail/userstory/117818565584?fdp=true
https://rally1.rallydev.com/#/89963236876d/detail/userstory/117681744096

Related:
https://github.com/Brightspace/user-tile/pull/28
https://github.com/Brightspace/parent-portal-ui/pull/150
https://github.com/Brightspace/d2l-evidence-tile/pull/11