### PR TITLE
Setting default loading state

### DIFF
--- a/d2l-tile.html
+++ b/d2l-tile.html
@@ -200,6 +200,7 @@
 			},
 			loading: {
 				type: Boolean,
+				value: false,
 				reflectToAttribute: true
 			}
 		},


### PR DESCRIPTION
Seeing some strange behavior when I don't set a default state for the loading attribute