### PR TITLE
Loading Adjustments

### DIFF
--- a/d2l-tile.html
+++ b/d2l-tile.html
@@ -122,6 +122,7 @@
 				position: relative;
 				background-color: var(--d2l-color-regolith);
 				box-shadow: inset 0 -1px 0 0 var(--d2l-color-gypsum);
+				border-radius: 7px 7px 0 0;
 			}
 
 			.loading-shimmer::after {


### PR DESCRIPTION
- ~~Don't apply `tabindex="0"` while tile is loading because the tile should be non-interactive at that time.~~
- Fixes the corner clipping in the shimmer animation.