### PR TITLE
Reflecting menu status to attribute

### DIFF
--- a/d2l-tile-behavior.html
+++ b/d2l-tile-behavior.html
@@ -1,0 +1,26 @@
+<script>
+	var TileBehaviorImpl = {
+		properties: {
+			menuOpened: {
+				type: Boolean,
+				value: false,
+				notify: true,
+				reflectToAttribute: true
+			}
+		},
+
+		listeners: {
+			'd2l-dropdown-open': '_onMenuOpen',
+			'd2l-dropdown-close': '_onMenuClose'
+		},
+		_onMenuOpen: function() {
+			this.menuOpened = true;
+		},
+
+		_onMenuClose: function() {
+			this.menuOpened = false;
+		},
+	};
+
+	D2LTileBehavior = [TileBehaviorImpl];
+</script>

--- a/d2l-tile.html
+++ b/d2l-tile.html
@@ -164,18 +164,18 @@
 				></div>
 			</template>
 		</div>
-			<d2l-dropdown on-tap="_onDropdownClick">
-				<d2l-dropdown-menu id="overflow-dropdown">
-					<slot name="tile-menu"></slot>
-				</d2l-dropdown-menu>
-				<template is="dom-if" if="[[_shouldShowMenu(showMenu, loading)]]">
-					<button class="menu-item no-tap-interaction d2l-dropdown-opener" aria-label$="[[dropdownAriaLabel]]">
-						<div class="elipsis-icon-container">
-							<d2l-icon class="elipsis-icon" icon="d2l-tier1:more"></d2l-icon>
-						</div>
-					</button>
-				</template>
-			</d2l-dropdown>
+		<d2l-dropdown on-tap="_onDropdownClick">
+			<d2l-dropdown-menu id="overflow-dropdown">
+				<slot name="tile-menu"></slot>
+			</d2l-dropdown-menu>
+			<template is="dom-if" if="[[_shouldShowMenu(showMenu, loading)]]">
+				<button class="menu-item no-tap-interaction d2l-dropdown-opener" aria-label$="[[dropdownAriaLabel]]">
+					<div class="elipsis-icon-container">
+						<d2l-icon class="elipsis-icon" icon="d2l-tier1:more"></d2l-icon>
+					</div>
+				</button>
+			</template>
+		</d2l-dropdown>
 		<div class="d2l-tile-content-container">
 			<slot></slot>
 		</div>
@@ -203,13 +203,31 @@
 				type: Boolean,
 				value: false,
 				reflectToAttribute: true
+			},
+			menuOpened: {
+				type: Boolean,
+				value: false,
+				notify: true,
+				reflectToAttribute: true
 			}
+		},
+		listeners: {
+			'd2l-dropdown-open': '_onMenuOpen',
+			'd2l-dropdown-close': '_onMenuClose'
 		},
 		hostAttributes: {
 			tabindex: 0
 		},
 		_onDropdownClick: function(e) {
 			e.stopPropagation();
+		},
+
+		_onMenuOpen: function() {
+			this.menuOpened = true;
+		},
+
+		_onMenuClose: function() {
+			this.menuOpened = false;
 		},
 		_hideImage: function() {
 			return !this.imgUrl || this.customImageFormat;

--- a/d2l-tile.html
+++ b/d2l-tile.html
@@ -3,6 +3,7 @@
 <link rel="import" href="../d2l-dropdown/d2l-dropdown.html">
 <link rel="import" href="../d2l-dropdown/d2l-dropdown-menu.html">
 <link rel="import" href="../d2l-colors/d2l-colors.html">
+<link rel="import" href="./d2l-tile-behavior.html">
 
 <dom-module id="d2l-tile">
 	<template>
@@ -185,6 +186,7 @@
 
 	Polymer({
 		is: 'd2l-tile',
+		behaviors: [D2LTileBehavior],
 		properties: {
 			dropdownAriaLabel: String,
 			imgUrl: String,
@@ -203,31 +205,13 @@
 				type: Boolean,
 				value: false,
 				reflectToAttribute: true
-			},
-			menuOpened: {
-				type: Boolean,
-				value: false,
-				notify: true,
-				reflectToAttribute: true
 			}
-		},
-		listeners: {
-			'd2l-dropdown-open': '_onMenuOpen',
-			'd2l-dropdown-close': '_onMenuClose'
 		},
 		hostAttributes: {
 			tabindex: 0
 		},
 		_onDropdownClick: function(e) {
 			e.stopPropagation();
-		},
-
-		_onMenuOpen: function() {
-			this.menuOpened = true;
-		},
-
-		_onMenuClose: function() {
-			this.menuOpened = false;
 		},
 		_hideImage: function() {
 			return !this.imgUrl || this.customImageFormat;


### PR DESCRIPTION
[Trello Card 920](https://trello.com/c/SpR7Px0R/920-folioedge-evidence-drop-down-menu-is-displayed-under-title-and-collected-date) is likely because the JS hack that we have in folio doesn't work because of shadow-dom. (Not applying z-index hack)

Adding a behavior to reflect the menu open/close status to the tile so that the application can deal with the z-index on a case-by-case basis.