### PR TITLE
Fix Firefox hover media query

### DIFF
--- a/d2l-tile.html
+++ b/d2l-tile.html
@@ -79,7 +79,7 @@
 				justify-content: center;
 			}
 
-			@media only screen and (hover: hover) {
+			@media only screen and (hover: hover), only screen and (-moz-touch-enabled: 0) {
 				d2l-dropdown > button {
 					opacity: 0;
 				}


### PR DESCRIPTION
Use Firefox's [experimental `-moz-touch-enabled` MQ](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#-moz-touch-enabled) to detect whether the screen is Firefox **AND** is not a touch screen.

Edit: A quick test on the media query: https://jsfiddle.net/kgwg6okt/

